### PR TITLE
ViewSong Page Completed, PlaylistCard and SongCard Now Renders an img

### DIFF
--- a/src/api/playlistData.js
+++ b/src/api/playlistData.js
@@ -2,10 +2,23 @@ import { clientCredentials } from '../utils/client';
 
 const endpoint = clientCredentials.databaseURL;
 
+// Temporarily commented this code out.
 // GET ALL PLAYLISTS
-const getPlaylists = (uid) =>
+// const getPlaylists = (uid) =>
+//   new Promise((resolve, reject) => {
+//     fetch(`${endpoint}/api/user/${uid}/playlists`, {
+//       method: 'GET',
+//       headers: {
+//         'Content-Type': 'application/json',
+//       },
+//     })
+//       .then((response) => response.json())
+//       .then((data) => resolve(Object.values(data)))
+//       .catch(reject);
+//   });
+const getPlaylists = () =>
   new Promise((resolve, reject) => {
-    fetch(`${endpoint}/api/user/${uid}/playlists`, {
+    fetch(`${endpoint}/api/playlists`, {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',

--- a/src/api/songData.js
+++ b/src/api/songData.js
@@ -34,7 +34,7 @@ const getSingleSong = (id) =>
       .then((data) => {
         // console.warn(data);
         if (data) {
-          resolve(Object.values(data));
+          resolve(data);
         } else {
           resolve([]);
         }

--- a/src/api/songData.js
+++ b/src/api/songData.js
@@ -22,4 +22,24 @@ const getSongs = () =>
       .catch(reject);
   });
 
-export default getSongs;
+const getSingleSong = (id) =>
+  new Promise((resolve, reject) => {
+    fetch(`${endpoint}/api/songs/${id}`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    })
+      .then((response) => response.json())
+      .then((data) => {
+        // console.warn(data);
+        if (data) {
+          resolve(Object.values(data));
+        } else {
+          resolve([]);
+        }
+      })
+      .catch(reject);
+  });
+
+export { getSongs, getSingleSong };

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import SongCard from '../components/SongCard';
-import getSongs from '../api/songData';
+import { getSongs } from '../api/songData';
 
 function Home() {
   const [songs, setSongs] = useState([]);

--- a/src/app/songs/[id]/page.js
+++ b/src/app/songs/[id]/page.js
@@ -21,7 +21,7 @@ export default function ViewSong({ params }) {
       <h1>Song Detail</h1>
       <div className="my-5 song-info">
         {/* TODO: Add an image here for the song */}
-
+        <img src={song?.album?.image} alt="Album cover." />
         {/* 
           Add ? before the period. This is called an optional chaining operator. Without it
           you might run into runtime errors.
@@ -38,7 +38,7 @@ export default function ViewSong({ params }) {
       </div>
 
       <div className="my-5 artist-info">
-        {/* TODO: add an image here for the artist */}
+        <img src={song?.artist?.image} alt="Artist" style={{ width: '40%', height: '40%' }} />
         <h2>Artist</h2>
         <p>{song?.artist?.name}</p>
       </div>

--- a/src/app/songs/[id]/page.js
+++ b/src/app/songs/[id]/page.js
@@ -5,28 +5,29 @@ import PropTypes from 'prop-types';
 import { getSingleSong } from '../../../api/songData';
 
 export default function ViewSong({ params }) {
-  const { id } = params;
-
   const [song, setSong] = useState({});
+
+  const { id } = params;
 
   useEffect(() => {
     getSingleSong(id).then(setSong);
   }, [id]);
 
   return (
-    <div className="border-1 text-center">
-      <div className="song-info">
+    <div className="text-center my-3">
+      <h1>Song Detail</h1>
+      <div className="my-5 song-info">
         {/* TODO: Add an image here for the song */}
         <h2>{song.name}</h2>
-        {/* <p>{song.album.name}</p>
-        <p>{song.genre.name}</p> */}
-        <p>Song length</p>
+        <p>{song.album.name}</p>
+        <p>{song.genre.name}</p>
+        <p>{song.length}</p>
       </div>
 
-      <div className="artist-info">
+      <div className="my-5 artist-info">
         {/* TODO: add an image here for the artist */}
         <h2>Artist</h2>
-        <p>Artist Name</p>
+        <p>{song.artist.name}</p>
       </div>
 
       <button className="btn btn-primary" type="button">

--- a/src/app/songs/[id]/page.js
+++ b/src/app/songs/[id]/page.js
@@ -1,5 +1,41 @@
-import React from 'react';
+'use client';
 
-export default function ViewSong() {
-  return <div>ViewSong</div>;
+import React, { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import { getSingleSong } from '../../../api/songData';
+
+export default function ViewSong({ params }) {
+  const { id } = params;
+
+  const [song, setSong] = useState({});
+
+  useEffect(() => {
+    getSingleSong(id).then(setSong);
+  }, [id]);
+
+  return (
+    <div className="border-1 text-center">
+      <div className="song-info">
+        {/* TODO: Add an image here for the song */}
+        <h2>{song.name}</h2>
+        {/* <p>{song.album.name}</p>
+        <p>{song.genre.name}</p> */}
+        <p>Song length</p>
+      </div>
+
+      <div className="artist-info">
+        {/* TODO: add an image here for the artist */}
+        <h2>Artist</h2>
+        <p>Artist Name</p>
+      </div>
+
+      <button className="btn btn-primary" type="button">
+        Add to playlist
+      </button>
+    </div>
+  );
 }
+
+ViewSong.propTypes = {
+  params: PropTypes.objectOf({}).isRequired,
+};

--- a/src/app/songs/[id]/page.js
+++ b/src/app/songs/[id]/page.js
@@ -5,7 +5,10 @@ import PropTypes from 'prop-types';
 import { getSingleSong } from '../../../api/songData';
 
 export default function ViewSong({ params }) {
-  const [song, setSong] = useState({});
+  // Set the initial state to null or else you will run into a runtime error. There's a chance
+  // the nested data is undefined (the returned data from the API call might not fire off before
+  // initial render).
+  const [song, setSong] = useState(null);
 
   const { id } = params;
 
@@ -18,16 +21,26 @@ export default function ViewSong({ params }) {
       <h1>Song Detail</h1>
       <div className="my-5 song-info">
         {/* TODO: Add an image here for the song */}
-        <h2>{song.name}</h2>
-        <p>{song.album.name}</p>
-        <p>{song.genre.name}</p>
-        <p>{song.length}</p>
+
+        {/* 
+          Add ? before the period. This is called an optional chaining operator. Without it
+          you might run into runtime errors.
+          
+          According to MDN, the object's properties we are trying
+          to access will instead evaluate to undefined instead of throwing errors.
+
+          https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining
+        */}
+        <h2>{song?.name}</h2>
+        <p>{song?.album.name}</p>
+        <p>{song?.genre.name}</p>
+        <p>{song?.length}</p>
       </div>
 
       <div className="my-5 artist-info">
         {/* TODO: add an image here for the artist */}
         <h2>Artist</h2>
-        <p>{song.artist.name}</p>
+        <p>{song?.artist?.name}</p>
       </div>
 
       <button className="btn btn-primary" type="button">

--- a/src/components/PlaylistCard.js
+++ b/src/components/PlaylistCard.js
@@ -6,6 +6,7 @@ import React from 'react';
 export default function PlaylistCard({ playlistObj }) {
   return (
     <div className="border my-3">
+      <img src={playlistObj.image} alt="playlist" style={{ width: '10rem', height: '10rem' }} />
       <p>{playlistObj.name}</p>
       <p>{playlistObj.categoryId}</p>
     </div>
@@ -16,5 +17,6 @@ PlaylistCard.propTypes = {
   playlistObj: PropTypes.shape({
     name: PropTypes.string,
     categoryId: PropTypes.string,
+    image: PropTypes.string,
   }).isRequired,
 };

--- a/src/components/SongCard.js
+++ b/src/components/SongCard.js
@@ -9,6 +9,10 @@ export default function SongCard({ songObj }) {
   return (
     <div className="row align-items-center border my-3 d-flex container" style={{ width: '70%', height: '7rem' }}>
       <div className="col">
+        <img src={songObj?.album?.image} alt="Album" style={{ width: '4.25rem', height: '4.25rem' }} />
+      </div>
+
+      <div className="col">
         <p>{songObj.name}</p>
       </div>
       <div className="col">
@@ -52,6 +56,7 @@ SongCard.propTypes = {
     }).isRequired,
     album: PropTypes.shape({
       name: PropTypes.string,
+      image: PropTypes.string,
     }).isRequired,
   }).isRequired,
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- DELETE ALL COMMENTS BEFORE CREATING PULL REQUEST -->

## Description
<!--- Describe your changes in detail -->
- Each PlaylistCard and SongCard is now rendering their respective image.
- Created a promise to retrieve a single song by its unique id.
- Temporarily commented out the getSongs promise. We will come back to it in a later commit to make sure user specific data is working (I'm probably doing something wrong).


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#13 and #16

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It addresses the problems that were outlined in the issue tickets. The user needs to see the details of the songs in their collection and the need to be able to add the song to a playlist.


## How Can This Be Tested?
<!--- Please describe in detail how teammates can test your changes. -->
Pull down the branch to your machine to test locally before merging this pull request.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
