### PR TITLE
Bug Fix for Creating Playlists

### DIFF
--- a/src/components/forms/PlaylistForm.jsx
+++ b/src/components/forms/PlaylistForm.jsx
@@ -39,10 +39,29 @@ export default function PlaylistForm({ obj = initialFormState }) {
   const handleChange = (e) => {
     const { name, value } = e.target;
 
-    setFormData((prevState) => ({
-      ...prevState,
-      [name]: value,
-    }));
+    // Handle the logic to properly update the the values in the category object from the initialFormState.
+    if (name === 'categoryId') {
+      // Store the value of the selected categoryId after finding it using the array.find method.
+      const selectedCategory = categories.find((category) => category.id === Number(value));
+
+      // Logs the category object
+      console.warn('selectedCategory: ', selectedCategory);
+
+      // Include the category object and the categoryId as part of whatever is currently stored in formData.
+      setFormData((prevState) => ({
+        ...prevState,
+        categoryId: selectedCategory.id,
+        category: {
+          id: selectedCategory.id,
+          name: selectedCategory.name,
+        },
+      }));
+    } else {
+      setFormData((prevState) => ({
+        ...prevState,
+        [name]: value,
+      }));
+    }
   };
 
   // Step five - handleSubmit.
@@ -109,7 +128,10 @@ PlaylistForm.propTypes = {
   obj: PropTypes.shape({
     name: PropTypes.string,
     image: PropTypes.string,
-    category: PropTypes.string,
+    category: PropTypes.shape({
+      id: PropTypes.number,
+      name: PropTypes.string,
+    }),
     categoryId: PropTypes.number,
     songs: PropTypes.arrayOf,
     isPublic: PropTypes.bool,

--- a/src/components/forms/PlaylistForm.jsx
+++ b/src/components/forms/PlaylistForm.jsx
@@ -52,7 +52,7 @@ export default function PlaylistForm({ obj = initialFormState }) {
         ...prevState,
         categoryId: selectedCategory.id,
         category: {
-          id: selectedCategory.id,
+          // id: selectedCategory.id,
           name: selectedCategory.name,
         },
       }));

--- a/src/components/forms/PlaylistForm.jsx
+++ b/src/components/forms/PlaylistForm.jsx
@@ -12,7 +12,13 @@ import getCategories from '../../api/categoryData';
 const initialFormState = {
   name: '',
   image: '',
-  categoryId: '',
+  categoryId: Number(''),
+  category: {
+    id: Number(''),
+    name: '',
+  },
+  songs: [],
+  isPublic: false,
 };
 export default function PlaylistForm({ obj = initialFormState }) {
   const { user } = useAuth();
@@ -32,6 +38,7 @@ export default function PlaylistForm({ obj = initialFormState }) {
   // Step four - handleChange. This will be used as a callback function.
   const handleChange = (e) => {
     const { name, value } = e.target;
+
     setFormData((prevState) => ({
       ...prevState,
       [name]: value,
@@ -62,8 +69,6 @@ export default function PlaylistForm({ obj = initialFormState }) {
       <h1 className="my-5">Playlist Form</h1>
 
       <Form onSubmit={handleSubmit} className="text-center" style={{ width: '50%' }}>
-        {/* TODO: Each Form.Control needs an onChange attribute. Pass in handleChange as a callback. */}
-
         {/* PLAYLIST NAME INPUT */}
         <Form.Group className="mb-3" controlId="">
           <Form.Label>Name</Form.Label>
@@ -85,7 +90,7 @@ export default function PlaylistForm({ obj = initialFormState }) {
             <option value="">Select ...</option>
             {/* TODO: map over values. Remember to add a key prop. */}
             {categories.map((category) => (
-              <option key={category.id} value={Number(category.id)}>
+              <option key={category.id} value={category.id}>
                 {category.name}
               </option>
             ))}
@@ -100,14 +105,13 @@ export default function PlaylistForm({ obj = initialFormState }) {
   );
 }
 
-// Note to self: your prop types should be structured the same way as the records in your DB. If your payload
-// doesn't match the structure, the server may reject your request.
 PlaylistForm.propTypes = {
   obj: PropTypes.shape({
     name: PropTypes.string,
     image: PropTypes.string,
     category: PropTypes.string,
     categoryId: PropTypes.number,
-    songs: PropTypes.bool,
+    songs: PropTypes.arrayOf,
+    isPublic: PropTypes.bool,
   }).isRequired,
 };


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
I was getting runtime errors that prevented playlists I created (or another user created) from rendering the playlist details. I didn't run into this issue with the preloaded data our backend crew made, so that made me dig deeper.

I realized that the payload (playlist) that I was sending to the server didn't match the same structure as the pre-existing data. I adjusted my prop types and added some additional logic in my handleChange callback to properly capture what the value of the dropdown item the user selects.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change ensures user-created playlists have the correct structure in terms of having all the properties and values the server expects.

## How Can This Be Tested?
<!--- Please describe in detail how teammates can test your changes. -->
Pull down branch and test locally.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
