### PR TITLE
Added Ability to Delete Songs from Private Playlists

### DIFF
--- a/src/components/forms/PlaylistForm.jsx
+++ b/src/components/forms/PlaylistForm.jsx
@@ -35,6 +35,14 @@ export default function PlaylistForm({ obj = initialFormState }) {
     if (obj.id) setFormData(obj);
   }, [obj, user]);
 
+  // Handle isPublic Toggle
+  const handleToggle = () => {
+    setFormData((prevState) => ({
+      ...prevState,
+      isPublic: !prevState.isPublic,
+    }));
+  };
+
   // Step four - handleChange. This will be used as a callback function.
   const handleChange = (e) => {
     const { name, value } = e.target;
@@ -115,7 +123,9 @@ export default function PlaylistForm({ obj = initialFormState }) {
             ))}
           </Form.Select>
         </Form.Group>
-
+        <button type="button" onClick={handleToggle}>
+          {formData.isPublic ? 'Public' : 'Private'}
+        </button>
         <button className="btn btn-primary" type="submit">
           {obj.id ? 'Update' : 'Create'} playlist
         </button>


### PR DESCRIPTION
**Description**

I added the ability for an authenticated user to be able to designate their playlist as either public or private.


## Related Issue

N/A


**Motivation and Context**

This ability will allow users to designate if they would like for their playlists to be viewable to all users or kept private for their use only.


**How Can This Be Tested?**

Pull down and manually test


Screenshots (if appropriate):

N/A


Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
